### PR TITLE
Issue #2: Truly convert/remove all non-latin characters if intl loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ nbproject
 .project
 .settings
 
-
 # mac deployment helpers
 switch
 index
+
+vendor/
+composer.lock

--- a/BaseTransliteratorHelper.php
+++ b/BaseTransliteratorHelper.php
@@ -33,7 +33,7 @@ class BaseTransliteratorHelper
 	{
 		// If intl extension load
 		if (extension_loaded('intl') === true) {
-			$options = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC;';
+			$options = 'Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove;';
 			return transliterator_transliterate($options, $string);
 		}
 		if (!preg_match('/[\x80-\xff]/', $string)) {


### PR DESCRIPTION
Convert cyrillic characters `ь` and `ъ` to ASCII-characters `'` and `"` instead prime-characters `ʹ` and `ʺ`.